### PR TITLE
Add action to wrap apt-get

### DIFF
--- a/apt-get-install/README.md
+++ b/apt-get-install/README.md
@@ -1,0 +1,19 @@
+# Run apt-get to install Debian/Ubuntu packages
+
+Installs packages on a Debian or Ubuntu runner. Does not support any other OS, but handles a few nuances of some packages that are fussy about their installation.
+
+## Inputs
+
+* `packages`
+
+  The space-separated list of packages to install. **Required.**
+
+  Example (two documentation tools): `doxygen python3-sphinx`
+
+## Outputs
+
+None.
+
+## Permissions
+
+No special permissions required.

--- a/apt-get-install/action.yml
+++ b/apt-get-install/action.yml
@@ -1,0 +1,38 @@
+# Copyright (c) 2020-2025 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Install Debian/Ubuntu packages"
+description: Runs apt-get to install Debian/Ubuntu packages.
+inputs:
+  packages:
+    description: The names of the packages to install.
+    required: true
+runs:
+  using: composite
+  steps:
+  - name: update
+    if: runner.os == 'Linux'
+    shell: bash
+    env:
+      CFGFILE: ${{ github.action_path }}/apt.conf
+    run: |
+      sudo apt-get -c "$CFGFILE" update
+  - name: install packages
+    if: runner.os == 'Linux'
+    shell: bash
+    env:
+      PACKAGES: ${{ inputs.packages }}
+      CFGFILE: ${{ github.action_path }}/apt.conf
+    run: |
+      sudo apt-get -c "$CFGFILE" install $PACKAGES

--- a/apt-get-install/apt.conf
+++ b/apt-get-install/apt.conf
@@ -1,0 +1,5 @@
+Dpkg::Use-Pty "0";
+APT::Get {
+    Fix-Missing "true";
+    Assume-Yes "true";
+};


### PR DESCRIPTION
This an action that handles some tricky nuances inside apt-get; some packages are otherwise _very_ insistent on seeking user input, despite that being impossible inside a Github Actions runner context.

Only supported on runners that use Ubuntu or Debian.

This action is based on [SpiNNakerManchester/SupportScripts/apt-get-install](https://github.com/SpiNNakerManchester/SupportScripts/blob/main/actions/apt-get-install/).