### PR TITLE
Commit ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This is a collection of Github Actions, mainly for University of Manchester use.
 
 [This](check-copyrights) ensures that all files in your repository have an "acceptable" copyright notice near their top.
 
+## `commit-id`
+
+[This](commit-id) helps generate a file containing the ID of the commit within it. 
+
 ## `compare-output`
 
 [This](compare-output) compares the output of a program to a string. Great for testing!

--- a/commit-id/README.md
+++ b/commit-id/README.md
@@ -1,0 +1,49 @@
+# Generate Commit ID
+
+Write the current commit ID to a file. Intended mainly for workflows triggered by `push` or that otherwise have a meaningful `github.sha`.
+
+It's up to the caller to make and check in the file with the pattern to
+replace in it; it is recommended that the pattern string only appear once.
+It's assumed that updated file will not be committed back to the repository; this is intended as an immediate pre-build step.
+
+## Example usage
+### C and C++
+
+```yml
+  - uses: UoMResearchIT/actions/commit-id@main
+    with:
+      file: src/build_id.h
+```
+
+Which might be paired with a source file (in `src/build_id.h` for example) like this for C or C++:
+```c
+/* Do not edit the next line manually. */
+#define COMMIT_ID   "undefined (dev build)"
+```
+### Python
+```yml
+  - uses: UoMResearchIT/actions/commit-id@main
+    with:
+      file: src/version.py
+```
+together with the file `src/version.py`:
+```py
+build_version: str = """undefined (dev build)"""
+```
+
+## Inputs
+
+* `file`
+
+  The name of the existing file to process. **Required.**
+
+  Example: `src/build_id.h`
+
+* `pattern`
+
+  The literal substring to replace. **Optional.**  
+  Defaults to `undefined (dev build)`
+
+## Outputs
+
+None.

--- a/commit-id/action.yml
+++ b/commit-id/action.yml
@@ -1,0 +1,23 @@
+name: Commit ID
+description: >
+  Generate a commit ID in a file.
+  It's up to the caller to make and check in the file with the pattern to
+  replace in it; it is recommended that the pattern string only appear once.
+inputs:
+  file:
+    description: What file to process.
+    required: true
+  pattern:
+    description: What substring to replace.
+    required: false
+    default: undefined (dev build)
+runs:
+  using: composite
+  steps:
+    - name: Run script
+      run: ${{ github.action_path }}/build-id.ps1
+      shell: pwsh
+      env:
+        BUILD_ID: ${{ inputs.file }}
+        PATTERN: ${{ inputs.pattern }}
+        REPLACEMENT: ${{ github.sha }}

--- a/commit-id/build-id.ps1
+++ b/commit-id/build-id.ps1
@@ -1,0 +1,3 @@
+Write-Output "Using build ID = $env:REPLACEMENT"
+(Get-Content $env:BUILD_ID).Replace($env:PATTERN, $env:REPLACEMENT) | Set-Content $env:BUILD_ID
+# sed -i -e "s/undefined .dev build./${{ github.sha }}/" $BUILD_ID


### PR DESCRIPTION
A simple action for generating a file containing the commit ID so that builds can describe what they were made from.

Subtasks:

- [x] Support Ubuntu runners
- [x] Support Windows runners
- [x] Support macOS runners