### PR TITLE
Cache whether 'apt-get update' is done

### DIFF
--- a/apt-get-install/action.yml
+++ b/apt-get-install/action.yml
@@ -22,13 +22,14 @@ runs:
   using: composite
   steps:
   - name: update
-    if: runner.os == 'Linux'
+    if: runner.os == 'Linux' && env.uomRIT_aptget_update != 'done'
     shell: bash
     env:
       CFGFILE: ${{ github.action_path }}/apt.conf
     run: |
       echo ::group::Update base system
       sudo apt-get -c "$CFGFILE" update
+      echo "uomRIT_aptget_update=done" >> $GITHUB_ENV
       echo ::endgroup::
   - name: install packages
     if: runner.os == 'Linux'


### PR DESCRIPTION
Notes in the environment that we have already processed an `apt-get update` so that we don't repeat the work. Useful especially for when the action is used as a component by other actions.