### PR TITLE
Add code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,21 +2,18 @@
 
 We will:
 
-* Follow the regulations of the University of Manchester for behaviour towards others in respect of [equality, diversity and inclusion](https://www.manchester.ac.uk/connect/jobs/equality-diversity-inclusion/).
-
-  (Technically, this is only a requirement of members of the University, but we expect others to follow the spirit of those rules while here, and they are part of rules we are required to enforce in respect of our work.)
-
 * Behave professionally.
-
 * Treat each other with respect.
+* Review the contribution, not the contributor, with one exact exception: whether the contributor is a member of the University of Manchester.
 
-* Review the contribution, not the contributor _(unless, by their **own** behaviour, the contributor **insists** otherwise)_.
+> [!IMPORTANT]
+> We will not normally accept contributions of actions from outside the University of Manchester (and its alumni, at our discretion) or where we cannot determine if the contribution is from the inside or outside of the University.
+> External parties can freely publish their own actions without any assistance from us.
 
 We will attempt to:
 
 * Resolve matters in a timely fashion.
-
 * Keep contributors informed of decisions (or reasons for delaying a decision) in regards to their contribution. 
 
 > [!NOTE]
-> The first four points are the code that we follow, and the other points extend that to the code that we aspire to follow.  Arguably, those are points that are part of _behaving professionally_ and _treating with respect_ but it helps to have them as explicit goals.
+> The first three points are the code that we follow, and the other points extend that to the code that we aspire to follow.  Arguably, those are points that are part of _behaving professionally_ and _treating with respect_ but it helps to have them as explicit goals.


### PR DESCRIPTION
This adds a [code of conduct](https://github.com/UoMResearchIT/actions/blob/code/.github/CODE_OF_CONDUCT.md) in accordance with [best practice](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project).