### PR TITLE
Move the reuse action code that doesn't use docker here

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ These are intended to support particular other repositories and working practice
 * [`check-ruleset-containment](check-ruleset-containment) checks whether a ruleset minimally conforms to another ruleset.
 
 * [`get-repo-ruleset`](get-repo-ruleset) gets the ruleset applied to a particular branch of a repository.
+
+* ['reuse'](reuse) checks that the licenses of all files conform to the REUSE standard.

--- a/reuse/README.md
+++ b/reuse/README.md
@@ -1,0 +1,91 @@
+<!--
+SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V. <https://fsfe.org>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+# REUSE Compliance Check
+
+[![REUSE status](https://api.reuse.software/badge/github.com/fsfe/reuse-action)](https://api.reuse.software/info/github.com/fsfe/reuse-action)
+
+Do you struggle with copyright and licensing in your project? REUSE helps you in three simple steps! Read more on [reuse.software](https://reuse.software) and run the short tutorial to learn how to make your copyright and licensing easy and clear.
+
+This action allows users to check for compliance with the REUSE best practices. It is one of many options for projects to include REUSE in their workflows. Please see the [help for developers](https://reuse.software/dev/) to get an overview.
+
+## Note
+
+This is a duplicate of the original ReUse action that we have made so that we can change the tool.  Unfortunately our needs are more than the tool developers are willing to accept (e.g. ignoring files is just not allowed in their action). So we copied it.
+
+## Features
+
+This action runs the `reuse lint` command over your repository to check the following information:
+
+* Is copyright and licensing information available for every single file?
+* Do license texts exist for all found license identifiers?
+* Are there any other problems with detecting copyright and licensing information?
+
+This action uses the [REUSE helper tool](https://github.com/fsfe/reuse-tool). For more features, please install the tool locally.
+
+## Example usage
+
+You can include the following lines in your workflow .yml file to run the lint subcommand:
+
+```yml
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  reuse-compliance-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v5
+```
+
+If you would like to run other subcommands, you could use the following snippet which outputs a the SPDX bill of materials:
+
+```yml
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: REUSE SPDX SBOM
+      uses: fsfe/reuse-action@v5
+      with:
+        args: spdx
+```
+
+In the same fashion, it is possible to add optional arguments like `--include-submodules`:
+
+```yml
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v5
+      with:
+        args: --include-submodules lint
+```
+
+
+## Inputs Description
+
+| Name   | Requirement | Default | Description |
+| ------ | ----------- | ------- | ----------- |
+| `args` | _required_  | `lint`  | The subcommand for the REUSE helper tool. Read the [tool's documentation](https://reuse.readthedocs.io/) for all available subcommands. |
+
+## Versions
+
+The major version of this action follows the major version of the [REUSE helper tool](https://github.com/fsfe/reuse-tool). Make sure to keep up with the latest major version to benefit from the latest features and be able to spot licensing and copyright issues that we detect with newer versions.
+
+
+## License
+
+This action itself is REUSE compliant, so copyright and licensing information is stored in every file. As of March 2020, all files are licensed under GPL-3.0-or-later.
+
+Using the [REUSE helper tool](https://github.com/fsfe/reuse-tool), you can run `reuse spdx` to get a full bill of materials.

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -1,6 +1,16 @@
-# SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V. <https://fsfe.org>
+# Copyright (c) 2025 The University of Manchester
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: 'REUSE Compliance Check'
 description: "Check your project's REUSE compliance for clear and simple licensing and copyright!"

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: 'REUSE Compliance Check'
+description: "Check your project's REUSE compliance for clear and simple licensing and copyright!"
+author: 'Free Software Foundation Europe (FSFE)'
+inputs:
+  args:
+    description: "The arguments to pass to the reuse-tool"
+    required: true
+  branch:
+    description: "The branch to check out the reuse-tool from"
+    required: false
+    default: "main"
+runs:
+  using: composite
+  steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+    with:
+      path: reuse-tool
+      repository: UoMResearchIT/reuse-tool
+      ref: ${{ inputs.branch }}
+
+  - name: Setup Environment
+    uses: getsentry/action-setup-venv@v2.1.0
+    with:
+      python-version: 3.12
+      cache-dependency-path: |
+        reuse-tool
+      venv-dir: reuse-tool-venv
+      install-cmd: |
+        pip install poetry~=1.3.0
+        cd reuse-tool
+        poetry install --no-interaction --only main
+        poetry build --no-interaction
+        pip install dist/*.whl
+
+  - name: Run reuse
+    shell: bash
+    run: |
+      source reuse-tool-venv/bin/activate
+      reuse ${{ inputs.args }}

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -34,7 +34,7 @@ runs:
       ref: ${{ inputs.branch }}
 
   - name: Setup Environment
-    uses: getsentry/action-setup-venv@v2.1.0
+    uses: getsentry/action-setup-venv@v2.1.1
     with:
       python-version: 3.12
       cache-dependency-path: |


### PR DESCRIPTION
This adds the REUSE action here, instead of having it in a separate repo.  I thought this made more sense, since the original repo will otherwise just have this one file in it!