### PR TITLE
Download with a bearer token

### DIFF
--- a/download/README.md
+++ b/download/README.md
@@ -14,8 +14,9 @@ Example of accessing a protected resource:
 ```yml
   - uses: UoMResearchIT/actions/download@main
     with:
-      url: https://github.com/UoMResearchIT/actions-test/
-      local-name: test-repo-page.html
+      url: https://api.github.com/repo/UoMResearchIT/actions=test/contents/README.md
+      local-name: read-me.md
+      content-type: application/vnd.github.raw+json
       token: ${{ secrets.MY_ACCESS_TOKEN }}
 ```
 
@@ -36,6 +37,13 @@ Example of accessing a protected resource:
 
   The local file name. Derived from the URL if not given.
   _Must_ be supplied if the guessed name would be empty. **Optional.**
+
+* `content-type`
+
+  The content type to try to download.
+  Defaults to whatever the server chooses by default. **Optional.**
+
+  Example: `text/html`
 
 * `token`
 

--- a/download/action.yml
+++ b/download/action.yml
@@ -31,6 +31,11 @@ inputs:
       A bearer token to present to authorise the download.
       If not supplied, only public resources may be accessed.
     required: false
+  content-type:
+    description: >
+      The content type to try to download.
+      Defaults to whatever the server chooses by default.
+    required: false
   wget-options:
     description: Additional options to pass to `wget`.
     required: false
@@ -63,6 +68,7 @@ runs:
         URL: ${{ inputs.url }}
         FILE: ${{ steps.filename.outputs.file }}
         TOKEN: ${{ inputs.token }}
+        CTY: ${{ inputs.content-type }}
         OPTIONS: ${{ inputs.wget-options }}
     - name: Do download
       if: steps.cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
@@ -72,4 +78,5 @@ runs:
         URL: ${{ inputs.url }}
         FILE: ${{ steps.filename.outputs.file }}
         TOKEN: ${{ inputs.token }}
+        CTY: ${{ inputs.content-type }}
         OPTIONS: ${{ inputs.wget-options }}

--- a/download/runwget.bash
+++ b/download/runwget.bash
@@ -20,5 +20,8 @@ read -a opts <<< "$OPTIONS"
 if [ -n "$TOKEN" ]; then
     opts+=("--header" "Authorization: token $TOKEN")
 fi
+if [ -n "$CTY" ]; then
+    opts+=("--header" "Accept: $CTY")
+fi
 
 wget --config=$GITHUB_ACTION_PATH/wgetrc -O "$FILE" "${opts[@]}" -- "$URL"

--- a/download/runwget.ps1
+++ b/download/runwget.ps1
@@ -19,5 +19,8 @@ $opts = (Select-String \S+ -input $env:OPTIONS -allmatches | ForEach-Object {$_.
 if ($env:TOKEN) {
     $opts += "--header","Authorization: token $env:TOKEN"
 }
+if ($env:CTY) {
+    $opts += "--header","Accept: $env:CTY"
+}
 
 & $wget --config=$env:GITHUB_ACTION_PATH\wgetrc -O $env:FILE @opts -- $env:URL


### PR DESCRIPTION
Adds support for supplying a bearer token to use for doing a download, especially so data can be downloaded from private Github repos.

Fixes #43 

---

- [x] Implement
- [x] Document
- [x] Test