### PR TITLE
Add a reusable workflow to add a PR to a project and set the status

### DIFF
--- a/.github/workflows/add_prs_to_project.yml
+++ b/.github/workflows/add_prs_to_project.yml
@@ -1,0 +1,136 @@
+# Copyright (c) 2025 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow adds a PR to a project.
+# To re-use in your repo:
+# name: Add PRs to Project
+# on:
+#   pull_request:
+#     types:
+#       - review_requested
+# jobs:
+#   call-add-prs-to-project:
+#     uses: UoMResearchIT/Actions/.github/workflows/add_prs_to_project.yml@main
+#     with:
+#       personal_access_token: ${{ secrets.TOKEN }}
+#
+
+name: Add PR to project
+on:
+  workflow_call:
+    inputs:
+      project_number:
+        type: number
+        required: true
+        description: >
+          The identifier of the project to add the PR to in the organisation being run in
+      status_to_change_to:
+        type: string
+        required: false
+        default: Ready To Review
+        description: >
+          The name of the option to select in as the Status field.  This workflow assumes that the project has a single select field called "Status" that includes an option that this value specifies.
+    secrets:
+      personal_access_token:
+        required: true
+        description: >
+          The access token to use to add the PR to the project.  Must have appropriate permissions.
+
+jobs:
+  track_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          # Aur
+          GH_TOKEN: ${{ secrets.personal_access_token }}
+          ORGANIZATION: SpiNNakerManchester
+          PROJECT_NUMBER: ${{ inputs.project_number }}
+        # Uses [GitHub CLI](https://cli.github.com/manual/) to query the API for the ID of the project and return the name and ID of the first 20 fields in the project. `fields` returns a union and the query uses inline fragments (`... on`) to return information about any `ProjectV2Field` and `ProjectV2SingleSelectField` fields. The response is stored in a file called `project_data.json`.
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+
+          # Parses the response from the API query and stores the relevant IDs as environment variables.
+          # **Note:** This workflow assumes that you have a project with a single select field called "Status" that includes an option specified in inputs.status_to_change_to.
+
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="${{ inputs.status_to_change_to }}") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add PR to project
+        env:
+          GH_TOKEN: ${{ secrets.personal_access_token }}
+          PR_ID: ${{ github.event.pull_request.node_id }}
+        # Uses [GitHub CLI](https://cli.github.com/manual/) and the API to add the pull request that triggered this workflow to the project. The `jq` flag parses the response to get the ID of the created item.
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $pr}) {
+                item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectV2ItemById.item.id')"
+
+          # Stores the ID of the created item as an environment variable.
+          echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      - name: Set fields
+        env:
+          GH_TOKEN: ${{ secrets.personal_access_token }}
+        # Sets the value of the `Status` field to `Ready to Review`.
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+            ) {
+              set_status: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: {
+                  singleSelectOptionId: $status_value
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.STATUS_OPTION_ID }} --silent

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ These are intended for use in many types of project, wherever relevant.
 
 * [`instantiate-file`](instantiate-file) creates a file with a value provided by your workflow.
 
+* ['add_prs_to_project (reusable workflow)](.github/workflows/add_prs_to_project.yml) is a reusable workflow that you can use in your repository to add any PRs assigned to a user to a Project and set the Status in the project to a value of your choosing.
+
 ## Linux runners only
 
 * [`apt-get-install`](apt-get-install) installs packages into Ubuntu runners, allowing for subtleties of installation that have been found to come up with some packages "in the wild".


### PR DESCRIPTION
---
name: ⭐ New Reusable Workflow
about: For submitting a new Reusable.
title: '[NEW]: '
labels: enhancement ⭐
type: Feature
---

- [x] Is this fixing an issue? If so, please `#ref` its ID. This helps a lot! (Note that an issue is _not_ required for submitting a new action.)
   Helps to fix UoMResearchIT/RSE-Peer-Support#53

- [x] What do you think this workflow does? We can see what it _actually_ does by reading the code,
      but it's very helpful to have a short description of what you _intend_ it to do.
      This workflow is used for adding any PRs where the reviewer is set to a Project of your chosing.  This could be used to
      add PRs to the project for the repo, or to a separate repo where all PRs are being tracked.

- [x] Have you considered whether there is an existing action by some other reasonably-trusted party to do this?
      This is based on code provided by GitHub as demo code but not seemingly actually made into an action anywhere!

- [x] If you can, `@` mention someone to review the code at least in the first instance.

- [x] Do you have new bash scripts in your PR? Did you remember to mark them as executable?
    Not required

- [x] Don't forget to give your action a `README.md`.
    Not an action.  There is some documentation at the top though.

- [x] Link to your action folder from the main `README.md`.
    Not an action, but added.

- [x] Your action descriptor (`action.yml`) should include
   Not an action, but there are some docs in there.

- [x] Consider whether your action interacts with itself and other actions.
  No interaction.

- [x] It helps a lot if you can link to a build log that shows that your action works.
  As a reusable workflow that works on PRs this is tricky... but I did copy this from the SpiNNaker repo where we have started to use it, and it works there e.g.:
    https://github.com/SpiNNakerManchester/sPyNNaker/actions/runs/16069343414/job/45350280226

