### PR TITLE
Making the reuse action easier to use

### DIFF
--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2024 University of Manchester
+#
+# SPDX-License-Identifier: apache-2.0
+
+name: Add License and Copyright Headers
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "What reference to check. Defaults to the one from the pull request invoking this."
+        type: string
+        required: false
+        default: ${{ github.event.pull_request.head.sha }}
+      work-dir:
+        description: "The working directory to check the code out into. Defaults to 'repo'."
+        type: string
+        required: false
+        default: repo
+      branch:
+        description: "The name of the branch."
+        type: string
+        required: false
+        default: ${{ github.head_ref }}
+      license:
+        description: "The SPDX name of the license to use."
+        type: string
+        required: false
+        default: apache-2.0
+    outputs:
+      check-failed:
+        description: "Whether the check applied by this workflow 'failed'."
+        value: ${{ jobs.add-headers.outputs.made-change == 1 }}
+      branch-created:
+        description: "If a branch was created, the name of that branch."
+        value: ${{ jobs.add-headers.outputs.made-change == 1 && jobs.add-headers.outputs.branch || '' }}
+      branches-deleted:
+        description: "If some branches were delete, what branches were they."
+        value: ${{ jobs.add-headers.outputs.deleted }}
+
+jobs:
+  add-headers:
+    runs-on: ubuntu-latest
+    outputs:
+      made-change: ${{ steps.push.outputs.changed }}
+      branch: ${{ steps.push.outputs.branch }}
+      deleted: ${{ steps.delete.outputs.deleted_branches }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: ${{ inputs.work-dir }}
+          ref: ${{ inputs.ref }}
+
+      - name: Add copyright headers
+        uses: UoMResearchIT/actions/reuse@reuse-usability
+        with:
+          base-dir: ${{ inputs.work-dir }}
+          extra-formats-file: ${{ inputs.work-dir }}/.extraformats
+          ignore-file: ${{ inputs.work-dir }}/.licenseignore
+          license: ${{ inputs.license }}
+
+      - name: Delete existing fix-headers branches
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@v2
+        id: delete
+        with:
+          github_token: ${{ github.token }}
+          last_commit_age_days: -1
+          allowed_prefixes: add-license-headers-to-${{ inputs.branch }}-
+          dry_run: no
+
+      - name: Commit and push changes
+        id: push
+        uses: UoMResearchIT/actions/git-push-changes-to-branch@main
+        with:
+          working-directory: ${{ inputs.work-dir }}
+          branch-prefix: add-license-headers-to
+          commit-message: Add License and Copyright Headers
+
+  annotate:
+    runs-on: ubuntu-latest
+    needs: add-headers
+    if: needs.add-headers.outputs.made-change == 1
+    steps:
+      - name: Commit comment if had to create new branch
+        uses: peter-evans/commit-comment@v3
+        with:
+          body: >
+            Copyright updates at [.../compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1), please review and merge.
+
+      - name: Fail if had to create new branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed("Copyright updates at ${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1, please review and merge.")

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -1,6 +1,16 @@
-# SPDX-FileCopyrightText: 2024 University of Manchester
+# Copyright (c) 2023-2025 The University of Manchester
 #
-# SPDX-License-Identifier: apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Add License and Copyright Headers
 on:

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -17,7 +17,7 @@ on:
         required: false
         default: repo
       branch:
-        description: "The name of the branch."
+        description: "The name of the branch, used when generating a diff."
         type: string
         required: false
         default: ${{ github.head_ref }}
@@ -40,6 +40,7 @@ on:
 jobs:
   add-headers:
     runs-on: ubuntu-latest
+    concurrency: prune:add-license-headers
     outputs:
       made-change: ${{ steps.push.outputs.changed }}
       branch: ${{ steps.push.outputs.branch }}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ These are intended for use in many types of project, wherever relevant.
 
 * [`add_prs_to_project` (reusable workflow)](.github/workflows/add_prs_to_project.yml) is a reusable workflow that you can use in your repository to add any PRs assigned to a user to a Project and set the Status in the project to a value of your choosing.
 
+* [`apply-reuse` (reusable workflow)](.github/workflows/apply-reuse.yml) is a reusable workflow that encodes how to use our branch of [reuse](https://reuse.software/) for managing copyright headers. Intended to be called from PR-triggered workflows.
+
 * [`scan-for-secrets` (reusable workflow)](.github/workflows/scan-for-secrets.yml) is a reusable workflow that you can use in your repository to scan for API keys (e.g., for AWS) that your code accidentally exposes.
 
 # Language-Specific Tools

--- a/reuse/README.md
+++ b/reuse/README.md
@@ -27,6 +27,9 @@ This action uses the [REUSE helper tool](https://github.com/fsfe/reuse-tool). Fo
 
 ## Example usage
 
+> [!NOTE]
+> See the `add_prs_to_project.yml` file in our standard workflow set for how to _actually_ use this action. These examples are outdated and incomplete.
+
 You can include the following lines in your workflow .yml file to run the lint subcommand:
 
 ```yml
@@ -72,12 +75,52 @@ In the same fashion, it is possible to add optional arguments like `--include-su
 ```
 
 ## Inputs
+* `copyright-holder`
+
+  The name of the copyright holder.
+  **Optional.** Defaults to `University of Manchester`.
+
+* `license`
+
+  The name of the license to apply.
+  **Optional.** Defaults to `apache-2.0`.
+
+* `merge`
+
+  Whether to merge copyrights.
+  **Optional.** Defaults to `true`.
+
+* `fallback-dot-license`
+
+  Whether to create a `*.license` file as a fallback. If `false`, will cause a failure if annotation isn't possible.
+  **Optional.** Defaults to `true`.
+
+* `extra-formats-file`
+
+  The name of the extra formats file.
+  **Optional.** Defaults to `.extraformats` in the current working directory.
+
+* `ignore-file`
+
+  The name of the ignore file.
+  **Optional.** Defaults to `.licenseignore` in the current working directory.
+
+* `base-dir`
+
+  The base directory to analyse and annotate.
+  **Optional.** Defaults to the current working directory.
+
 * `args`
 
   The subcommand for the REUSE helper tool. Read the [tool's documentation](https://reuse.readthedocs.io/) for all available subcommands.
   **Optional.**
 
-  Defaults to `lint`.
+  Overrides all other options (except `branch`).
+
+* `branch`
+
+  The branch to check out the `reuse-tool` from.
+  **Optional.** _Very_ rarely required.
 
 ## Outputs
 None

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -23,6 +23,34 @@ inputs:
     description: "The branch to check out the reuse-tool from"
     required: false
     default: "main"
+  copyright-holder:
+    description: "The name of the copyright holder"
+    required: false
+    default: "University of Manchester"
+  license:
+    description: "The name of the license to apply"
+    required: false
+    default: "apache-2.0"
+  merge:
+    description: "Whether to merge copyrights"
+    required: false
+    default: "true"
+  fallback-dot-license:
+    description: "Whether to create a .license file as a fallback"
+    required: false
+    default: "true"
+  extra-formats-file:
+    description: "The name of the extra formats file"
+    required: false
+    default: ".extraformats"
+  ignore-file:
+    description: "The name of the ignore file"
+    required: false
+    default: ".licenseignore"
+  base-dir:
+    description: "The base directory to analyse and annotate"
+    required: false
+    default: "."
 runs:
   using: composite
   steps:
@@ -79,8 +107,23 @@ runs:
       key: ${{ steps.cache-venv.outputs.cache-primary-key }}
     if: steps.cache-venv.outputs.cache-hit != 'true'
 
+  - name: Set Up Arguments
+    id: args
+    shell: bash
+    env:
+      Arguments: ${{ inputs.args }}
+      Who: ${{ inputs.copyright-holder }}
+      License: ${{ inputs.license }}
+      Merge: ${{ inputs.merge }}
+      Fallback: ${{ inputs.fallback-dot-license }}
+      Extra: ${{ inputs.extra-formats-file }}
+      Ignore: ${{ inputs.ignore-file }}
+      Dir: ${{ inputs.base-dir }}
+    run: |
+      $GITHUB_ACTION_PATH/compose-args.bash
+
   - name: Run reuse
     shell: bash
     run: |
       source reuse-tool-venv/bin/activate
-      reuse ${{ inputs.args }}
+      reuse ${{ steps.args.outputs.args }}

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -18,7 +18,8 @@ author: 'Free Software Foundation Europe (FSFE)'
 inputs:
   args:
     description: "The arguments to pass to the reuse-tool"
-    required: true
+    required: false
+    default: ""
   branch:
     description: "The branch to check out the reuse-tool from"
     required: false

--- a/reuse/compose-args.bash
+++ b/reuse/compose-args.bash
@@ -19,7 +19,7 @@ set -e
 # If a full set of args supplied, skip generating them
 if [ -z "$Arguments" ]; then
     # Basic arguments
-    Arguments="annotate --copyright \"$Who\" -license '$License' --recursive"
+    Arguments="annotate --copyright \"$Who\" --license '$License' --recursive"
 
     # Add if flag set
     if [ "$Merge" == 'true' ]; then

--- a/reuse/compose-args.bash
+++ b/reuse/compose-args.bash
@@ -1,0 +1,52 @@
+#!/usr/bin/bash
+
+# Copyright (c) 2025 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# If a full set of args supplied, skip generating them
+if [ -z "$Arguments" ]; then
+    # Basic arguments
+    Arguments="annotate --copyright \"$Who\" -license '$License' --recursive"
+
+    # Add if flag set
+    if [ "$Merge" == 'true' ]; then
+        Arguments="$Arguments --merge-copyrights"
+    fi
+
+    # Add if flag set
+    if [ "$Fallback" == 'true' ]; then
+        Arguments="$Arguments --fallback-dot-license"
+    fi
+
+    # Add if file exists
+    if [ -f "$Extra" ]; then
+        Arguments="$Arguments --extra-formats '$Extra'"
+    fi
+
+    # Add if file exists
+    if [ -f "$Ignore" ]; then
+        Arguments="$Arguments --ignore-file '$Ignore'"
+    fi
+
+    # Add if directory exists, else use fallback
+    if [ -d "$Dir" ]; then
+        Arguments="$Arguments '$Dir'"
+    else
+        Arguments="$Arguments ."
+    fi
+fi
+
+echo "args=$Arguments" #>>$GITHUB_OUTPUT

--- a/reuse/compose-args.bash
+++ b/reuse/compose-args.bash
@@ -49,4 +49,4 @@ if [ -z "$Arguments" ]; then
     fi
 fi
 
-echo "args=$Arguments" #>>$GITHUB_OUTPUT
+echo "args=$Arguments" >>$GITHUB_OUTPUT

--- a/reuse/compose-args.bash
+++ b/reuse/compose-args.bash
@@ -33,12 +33,12 @@ if [ -z "$Arguments" ]; then
 
     # Add if file exists
     if [ -f "$Extra" ]; then
-        Arguments="$Arguments --extra-formats '$Extra'"
+        Arguments="--extra-formats '$Extra' $Arguments"
     fi
 
     # Add if file exists
     if [ -f "$Ignore" ]; then
-        Arguments="$Arguments --ignore-file '$Ignore'"
+        Arguments="--ignore-file '$Ignore' $Arguments"
     fi
 
     # Add if directory exists, else use fallback


### PR DESCRIPTION
This makes the `reuse` action easier to use. Instead of having an undifferentiated pile of arguments, it presents a more ordered set of options with better descriptions of what they mean. The general arguments remain as an override for now.

This means that usages will do:
```yml
      - name: Add our copyright headers
        uses: UoMResearchIT/actions/reuse@...
        with:
          base-dir: ${{ env.SUBDIR }}
          extra-formats-file: ${{ env.SUBDIR }}/.extraformats
          ignore-file: ${{ env.SUBDIR }}/.licenseignore
```
instead of:
```yml
      - name: Add our copyright headers
        uses: UoMResearchIT/actions/reuse@...
          args: >
            --ignore-file ${{ env.SUBDIR }}/.licenseignore
            --extra-formats ${{ env.SUBDIR }}/.extraformats
            annotate
            --fallback-dot-license
            --merge-copyrights
            --copyright "University of Manchester"
            --license "apache-2.0"
            --recursive ${{ env.SUBDIR }}
```

This is _particularly_ good as the order of arguments is a little non-obvious when writing things out in full. (The action also can now handle missing `.licenseignore` and `.extraformats` files, since it understands what they are in the first place, which it's hard to do with undifferentiated arguments.)

I _then also_ define a new reusable workflow, allowing the main check workflows to become (branch name must change when deployed after this PR is committed):
```yml
name: Add License and Copyright Headers
on: pull_request
run-name: Checking copyright headers for ${{ github.head_ref }}
permissions:
  pull-requests: write
  contents: write

jobs:
  check-copyright-headers:
    uses: UoMResearchIT/actions/.github/workflows/apply-reuse.yml@reuse-usability
    with:
      ref: ${{ github.event.pull_request.head.sha }}
      branch: ${{ github.head_ref }}
      work-dir: repo
```

## The new action inputs
* `copyright-holder`

  The name of the copyright holder.
  **Optional.** Defaults to `University of Manchester`.

* `license`

  The name of the license to apply.
  **Optional.** Defaults to `apache-2.0`.

* `merge`

  Whether to merge copyrights.
  **Optional.** Defaults to `true`.

* `fallback-dot-license`

  Whether to create a `*.license` file as a fallback. If `false`, will cause a failure if annotation isn't possible.
  **Optional.** Defaults to `true`.

* `extra-formats-file`

  The name of the extra formats file.
  **Optional.** Defaults to `.extraformats` in the current working directory.

* `ignore-file`

  The name of the ignore file.
  **Optional.** Defaults to `.licenseignore` in the current working directory.

* `base-dir`

  The base directory to analyse and annotate.
  **Optional.** Defaults to the current working directory.

