### PR TITLE
Reuse surface

### DIFF
--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -100,6 +100,7 @@ jobs:
             Copyright updates at [.../compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1), please review and merge.
 
       - name: Hide old PR comments
+        if: needs.add-headers.outputs.made-change == 0
         uses: kanga333/comment-hider@v0.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -108,6 +109,7 @@ jobs:
         if: needs.add-headers.outputs.made-change == 1
         uses: mshick/add-pr-comment@v2
         with:
+          refresh-message-position: true
           message: |
             ## Changes were made to copyright notices
             There are copyright updates on the (temporary) [${{ needs.add-headers.outputs.branch }} branch](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1). Please review and merge, or add further commits (this branch will be deleted).

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -89,16 +89,31 @@ jobs:
 
   annotate:
     runs-on: ubuntu-latest
+    concurrency: prune:bot-comments
     needs: add-headers
-    if: needs.add-headers.outputs.made-change == 1
     steps:
-      - name: Commit comment if had to create new branch
+      - name: Commit comment
+        if: needs.add-headers.outputs.made-change == 1
         uses: peter-evans/commit-comment@v3
         with:
           body: >
             Copyright updates at [.../compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1), please review and merge.
 
-      - name: Fail if had to create new branch
+      - name: Hide old PR comments
+        uses: kanga333/comment-hider@v0.4.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: PR comment
+        if: needs.add-headers.outputs.made-change == 1
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            ## Changes were made to copyright notices
+            There are copyright updates on the (temporary) [${{ needs.add-headers.outputs.branch }} branch](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1). Please review and merge, or add further commits (this branch will be deleted).
+
+      - name: Fail marker
+        if: needs.add-headers.outputs.made-change == 1
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
This updates the reusable workflow for `reuse` so that it also adds (and maintains, so that the comment stays valid) a comment on the PR when it had to add the branch. See UoMResearchIT/actions-test#14 for a demo.