### PR TITLE
Trying to allow excluding a path

### DIFF
--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -81,11 +81,12 @@ jobs:
 
       - name: Commit and push changes
         id: push
-        uses: UoMResearchIT/actions/git-push-changes-to-branch@main
+        uses: UoMResearchIT/actions/git-push-changes-to-branch@omit-workflows-from-commits
         with:
           working-directory: ${{ inputs.work-dir }}
           branch-prefix: add-license-headers-to
           commit-message: Add License and Copyright Headers
+          exclude: .github/workflows/*
 
   annotate:
     runs-on: ubuntu-latest

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -88,6 +88,10 @@ jobs:
           commit-message: Add License and Copyright Headers
           exclude: .github/workflows/*
 
+      - run: |
+          echo "changed='${{steps.push.outputs.changed}}', branch='${{steps.push.outputs.branch}}'"
+        shell: bash
+
   annotate:
     runs-on: ubuntu-latest
     concurrency: prune:bot-comments

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -39,10 +39,10 @@ on:
     outputs:
       check-failed:
         description: "Whether the check applied by this workflow 'failed'."
-        value: ${{ jobs.add-headers.outputs.made-change == 1 }}
+        value: ${{ jobs.add-headers.outputs.made-change }}
       branch-created:
         description: "If a branch was created, the name of that branch."
-        value: ${{ jobs.add-headers.outputs.made-change == 1 && jobs.add-headers.outputs.branch || '' }}
+        value: ${{ jobs.add-headers.outputs.made-change && jobs.add-headers.outputs.branch || '' }}
       branches-deleted:
         description: "If some branches were delete, what branches were they."
         value: ${{ jobs.add-headers.outputs.deleted }}
@@ -88,30 +88,26 @@ jobs:
           commit-message: Add License and Copyright Headers
           exclude: .github/workflows/*
 
-      - run: |
-          echo "changed='${{steps.push.outputs.changed}}', branch='${{steps.push.outputs.branch}}'"
-        shell: bash
-
   annotate:
     runs-on: ubuntu-latest
     concurrency: prune:bot-comments
     needs: add-headers
     steps:
       - name: Commit comment
-        if: needs.add-headers.outputs.made-change == 1
+        if: needs.add-headers.outputs.made-change
         uses: peter-evans/commit-comment@v4
         with:
           body: >
             Copyright updates at [.../compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1), please review and merge.
 
       - name: Hide old PR comments
-        if: needs.add-headers.outputs.made-change == 0
+        if: ${{ !needs.add-headers.outputs.made-change }}
         uses: kanga333/comment-hider@v0.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PR comment
-        if: needs.add-headers.outputs.made-change == 1
+        if: needs.add-headers.outputs.made-change
         uses: mshick/add-pr-comment@v2
         with:
           refresh-message-position: true
@@ -120,7 +116,7 @@ jobs:
             There are copyright updates on the (temporary) [${{ needs.add-headers.outputs.branch }} branch](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1). Please review and merge, or add further commits (this branch will be deleted).
 
       - name: Fail marker
-        if: needs.add-headers.outputs.made-change == 1
+        if: needs.add-headers.outputs.made-change
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Commit and push changes
         id: push
-        uses: UoMResearchIT/actions/git-push-changes-to-branch@omit-workflows-from-commits
+        uses: UoMResearchIT/actions/git-push-changes-to-branch@main
         with:
           working-directory: ${{ inputs.work-dir }}
           branch-prefix: add-license-headers-to

--- a/git-push-changes-to-branch/README.md
+++ b/git-push-changes-to-branch/README.md
@@ -63,11 +63,11 @@ Example:
 * `branch`
 
   The name of the branch that may have been created.
-  NB: The branch is only created if the `changed` output is `1`.
+  NB: The branch is only created if the `changed` output is `true`.
 
 * `changed`
 
-  Whether there were any changes committed. (`1` if yes, `0` if no.)
+  Whether there were any changes committed. (`true` if yes, `false` if no.)
 
 ## Permissions
 Required permission:

--- a/git-push-changes-to-branch/action.yml
+++ b/git-push-changes-to-branch/action.yml
@@ -59,7 +59,7 @@ outputs:
   changed:
     description: >
       Whether there were any changes committed.
-    value: ${{ steps.push.outputs.work == 1 }}
+    value: ${{ steps.detect.outputs.changed == 1 && steps.push.outputs.pushed == 1 }}
 runs:
   using: composite
   steps:
@@ -106,11 +106,11 @@ runs:
           git add --all -- "${EXCLUDE/#/:!}"
         fi
         if git diff --cached --exit-code >/dev/null; then
-          echo "work=0" >> $GITHUB_OUTPUT
+          echo "pushed=0" >> $GITHUB_OUTPUT
         else
           git commit -a -m "$MESSAGE"
           git push origin "$NEW_BRANCH"
-          echo "work=1" >> $GITHUB_OUTPUT
+          echo "pushed=1" >> $GITHUB_OUTPUT
         fi
       shell: bash
       env:

--- a/git-push-changes-to-branch/action.yml
+++ b/git-push-changes-to-branch/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: >
       The email address of the user to ascribe the commit to.
     default: no-reply@github.com
+  exclude:
+    description: >
+      A pattern to describe what files to omit from the committed.
+    default: ""
 outputs:
   branch:
     description: >
@@ -55,7 +59,7 @@ outputs:
   changed:
     description: >
       Whether there were any changes committed.
-    value: ${{ steps.detect.outputs.changed }}
+    value: ${{ steps.push.outputs.work == 1 }}
 runs:
   using: composite
   steps:
@@ -92,14 +96,25 @@ runs:
         USER_EMAIL: ${{ inputs.commit-user-email }}
     - name: push changes
       if: steps.detect.outputs.changed == 1
+      id: push
       working-directory: ${{ inputs.working-directory }}
       run: |
         git checkout -b "$NEW_BRANCH"
-        git add -A
-        git commit -a -m "$MESSAGE"
-        git push origin "$NEW_BRANCH"
+        if [ -z "$EXCLUDE" ]; then
+          git add -A
+        else
+          git add --all -- "${EXCLUDE/#/:!}"
+        fi
+        if git diff --cached --exit-code >/dev/null; then
+          echo "work=0" >> $GITHUB_OUTPUT
+        else
+          git commit -a -m "$MESSAGE"
+          git push origin "$NEW_BRANCH"
+          echo "work=1" >> $GITHUB_OUTPUT
+        fi
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
         NEW_BRANCH: ${{ steps.name.outputs.branch }}
         MESSAGE: ${{ inputs.commit-message }}
+        EXCLUDE: ${{ inputs.exclude }}


### PR DESCRIPTION
Add the ability to exclude a path or paths from a commit made by `git-push-changes-to-branch`. Use that in `apply-reuse` to avoid making changes to workflow files, which are tangled up in special permissions. Fixes #101 