### PR TITLE
By default, repositories should have no license

### DIFF
--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -35,7 +35,7 @@ on:
         description: "The SPDX name of the license to use."
         type: string
         required: false
-        default: apache-2.0
+        default: LicenseRef-NONE
     outputs:
       check-failed:
         description: "Whether the check applied by this workflow 'failed'."


### PR DESCRIPTION
Updates the default action runner to use no license.  This is used by UoMResearchIT/RSE-Repository-Template#77