### PR TITLE
Fetch default branch name from correct repo

### DIFF
--- a/get-repo-ruleset/fetch.bash
+++ b/get-repo-ruleset/fetch.bash
@@ -25,7 +25,7 @@ OUTPUT_FILE=$(realpath $OUTPUT_FILE.json)
 
 if [ -z "$BRANCH" ]; then
     # Fetch default branch dynamically
-    DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+    DEFAULT_BRANCH=$(gh repo view "$REPO_NAME" --json defaultBranchRef --jq .defaultBranchRef.name)
     echo "Default branch detected: $DEFAULT_BRANCH"
     BRANCH=$DEFAULT_BRANCH
 fi


### PR DESCRIPTION
Read the default branch name from the correct repository, where permission has been granted to look. This fixes #123. 