### PR TITLE
List deployment environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ These are intended for use in many types of project, wherever relevant.
 
 * [`instantiate-file`](instantiate-file) creates a file with a value provided by your workflow.
 
+* [`list-environments`](list-environments) lists deployment environments that a workflow may use to deploy.
+
 ## Linux runners only
 
 * [`apt-get-install`](apt-get-install) installs packages into Ubuntu runners, allowing for subtleties of installation that have been found to come up with some packages "in the wild".

--- a/list-environments/README.md
+++ b/list-environments/README.md
@@ -15,10 +15,18 @@ Example:
 
   Defaults to the `GITHUB_TOKEN`.
 
+* `has-env`
+
+  If given, describes whether the specific named environment is defined. **Optional.**
+
 ## Outputs
 * `environments`
 
   A JSON list of all environment names, as a string.
+
+* `env-present`
+
+  Whether the environment named in the `has-env` input is present. `false` if no environment is named.
 
 ## Permissions
 Requires at least `actions: read`, and very likely `contents: read` implicitly as well

--- a/list-environments/README.md
+++ b/list-environments/README.md
@@ -1,0 +1,25 @@
+# List Deployment Environments
+
+Gets the list of deployment environments that the current repository knows about.
+
+Example:
+```yml
+  - uses: UoMResearchIT/actions/list-environments@list-envs
+    id: list
+```
+
+## Inputs
+* `token`
+
+  An alternative token to use to access the Github API endpoint. **Optional.**
+
+  Defaults to the `GITHUB_TOKEN`.
+
+## Outputs
+* `environments`
+
+  A JSON list of all environment names, as a string.
+
+## Permissions
+Requires at least `actions: read`, and very likely `contents: read` implicitly as well
+(because it must be run within a checkout).

--- a/list-environments/action.yml
+++ b/list-environments/action.yml
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: List Deployment Environments
+author: Donal Fellows
+description: >
+  Gets a list of the names of deployment environments.
+branding:
+  icon: list
+  color: gray-dark
+inputs:
+  token:
+    description: >
+      The access token to use.
+    default: ${{ github.token }}
+outputs:
+  environments:
+    description: The JSON array of environment names.
+    value: ${{ steps.list.outputs.environments }}
+runs:
+  using: composite
+  steps:
+    - name: List Deployment Environments
+      shell: bash
+      id: list
+      run: |
+        envs="$(gh api repos/{owner}/{repo}/environments --jq '
+          .environments | map(.name)
+        ')"
+        echo "environments=$envs" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ inputs.token }}

--- a/list-environments/action.yml
+++ b/list-environments/action.yml
@@ -24,10 +24,19 @@ inputs:
     description: >
       The access token to use.
     default: ${{ github.token }}
+    required: false
+  has-env:
+    description: >
+      If given, describes whether a specific environment is defined.
+    required: false
+    default: ""
 outputs:
   environments:
     description: The JSON array of environment names.
     value: ${{ steps.list.outputs.environments }}
+  env-present:
+    description: Whether the named environment is present.
+    value: ${{ inputs.has-env != '' && contains(inputs.has-env, fromJSON(steps.list.outputs.environments)) }}
 runs:
   using: composite
   steps:

--- a/list-environments/action.yml
+++ b/list-environments/action.yml
@@ -35,9 +35,10 @@ runs:
       shell: bash
       id: list
       run: |
-        envs="$(gh api repos/{owner}/{repo}/environments --jq '
+        envs="$(gh api repos/{owner}/{repo}/environments | jq -c '
           .environments | map(.name)
         ')"
+        echo "$envs" | jq -r '.[]'
         echo "environments=$envs" >> $GITHUB_OUTPUT
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
This adds an action for inquiring whether a deployment environment is available. Deployment environments are used with the [actions/deploy-pages](https://github.com/actions/deploy-pages) action, and this action makes it easier to gate access to the environment on whether the necessary configuration has been done.

Test evidence/usage pattern: UoMResearchIT/Control-System-GUI-2DS#16