### PR TITLE
Scan for vulnerabilities in GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,4 @@ updates:
     assignees:
       - dkfellows
     cooldown:
-      default-days: 3
+      default-days: 7

--- a/.github/workflows/add_prs_to_project.yml
+++ b/.github/workflows/add_prs_to_project.yml
@@ -64,6 +64,7 @@ on:
 
 jobs:
   track_pr:
+    name: Add PR
     runs-on: ubuntu-latest
     steps:
       - name: Get project data

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -72,7 +72,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ inputs.work-dir }}
           ref: ${{ inputs.ref }}
@@ -118,20 +118,20 @@ jobs:
     steps:
       - name: Commit comment
         if: needs.add-headers.outputs.made-change == 'true'
-        uses: peter-evans/commit-comment@v4
+        uses: peter-evans/commit-comment@f6d60c65d05bb59f750fa51ad3de1d443ba0eb52 # v4.0.0
         with:
           body: >
             Copyright updates at [.../compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1), please review and merge.
 
       - name: Hide old PR comments
         if: needs.add-headers.outputs.made-change == 'false'
-        uses: kanga333/comment-hider@v0.4.0
+        uses: kanga333/comment-hider@c12bb20b48aeb8fc098e35967de8d4f8018fffdf # v0.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PR comment
         if: needs.add-headers.outputs.made-change == 'true'
-        uses: mshick/add-pr-comment@v3
+        uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0
         with:
           refresh-message-position: true
           message: |
@@ -140,7 +140,7 @@ jobs:
 
       - name: Fail marker
         if: needs.add-headers.outputs.made-change == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed(`Copyright updates at ${process.env.COMPARE_URL}, please review and merge.`)

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -56,6 +56,9 @@ permissions: {}
 
 jobs:
   add-headers:
+    name: Add Headers
+    # Categorically never run this in pull_request_target workflows. UNSAFE TO DO THAT!
+    if: github.event_name != 'pull_request_trigger'
     runs-on: ubuntu-latest
     concurrency:
       group: prune:add-license-headers
@@ -103,6 +106,7 @@ jobs:
           exclude: .github/workflows/*
 
   annotate:
+    name: Annotate PR
     runs-on: ubuntu-latest
     concurrency:
       group: prune:bot-comments

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -52,20 +52,28 @@ on:
         description: "If some branches were delete, what branches were they."
         value: ${{ jobs.add-headers.outputs.deleted }}
 
+permissions: {}
+
 jobs:
   add-headers:
     runs-on: ubuntu-latest
-    concurrency: prune:add-license-headers
+    concurrency:
+      group: prune:add-license-headers
+      cancel-in-progress: false
+      queue: max
     outputs:
       made-change: ${{ steps.push.outputs.changed }}
       branch: ${{ steps.push.outputs.branch }}
       deleted: ${{ steps.delete.outputs.deleted_branches }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           path: ${{ inputs.work-dir }}
           ref: ${{ inputs.ref }}
+          persist-credentials: true
 
       - name: Add copyright headers
         uses: UoMResearchIT/actions/reuse@v1.2.4
@@ -96,8 +104,13 @@ jobs:
 
   annotate:
     runs-on: ubuntu-latest
-    concurrency: prune:bot-comments
+    concurrency:
+      group: prune:bot-comments
+      queue: max
+      cancel-in-progress: false
     needs: add-headers
+    permissions:
+      pull-requests: write
     steps:
       - name: Commit comment
         if: needs.add-headers.outputs.made-change == 'true'

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -116,6 +116,7 @@ jobs:
     needs: add-headers
     permissions:
       pull-requests: write
+      contents: read
     steps:
       - name: Commit comment
         if: needs.add-headers.outputs.made-change == 'true'

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -89,7 +89,7 @@ jobs:
           copyright-holder: ${{ inputs.copyright-holder }}
 
       - name: Delete existing fix-headers branches
-        uses: phpdocker-io/github-actions-delete-abandoned-branches@e04764c2f0f714dedb80c42d5174e756568a0452 # v2.02
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@e04764c2f0f714dedb80c42d5174e756568a0452 # v2.0.2
         id: delete
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -126,4 +126,6 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            core.setFailed("Copyright updates at ${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1, please review and merge.")
+            core.setFailed(`Copyright updates at ${process.env.COMPARE_URL}, please review and merge.`)
+        env:
+          COMPARE_URL: ${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -70,6 +70,7 @@ jobs:
       deleted: ${{ steps.delete.outputs.deleted_branches }}
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -80,7 +81,6 @@ jobs:
 
       - name: Add copyright headers
         uses: UoMResearchIT/actions/reuse@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
-
         with:
           base-dir: ${{ inputs.work-dir }}
           extra-formats-file: ${{ inputs.work-dir }}/.extraformats

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -89,7 +89,7 @@ jobs:
           copyright-holder: ${{ inputs.copyright-holder }}
 
       - name: Delete existing fix-headers branches
-        uses: phpdocker-io/github-actions-delete-abandoned-branches@e04764c2f0f714dedb80c42d5174e756568a0452 # v2.0.2
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@e04764c2f0f714dedb80c42d5174e756568a0452 # v2.0.3
         id: delete
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -79,7 +79,8 @@ jobs:
           persist-credentials: true
 
       - name: Add copyright headers
-        uses: UoMResearchIT/actions/reuse@v1.2.4
+        uses: UoMResearchIT/actions/reuse@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+
         with:
           base-dir: ${{ inputs.work-dir }}
           extra-formats-file: ${{ inputs.work-dir }}/.extraformats
@@ -98,7 +99,7 @@ jobs:
 
       - name: Commit and push changes
         id: push
-        uses: UoMResearchIT/actions/git-push-changes-to-branch@v1.2.4
+        uses: UoMResearchIT/actions/git-push-changes-to-branch@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
         with:
           working-directory: ${{ inputs.work-dir }}
           branch-prefix: add-license-headers-to

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -116,7 +116,7 @@ jobs:
     needs: add-headers
     permissions:
       pull-requests: write
-      contents: read
+      contents: write
     steps:
       - name: Commit comment
         if: needs.add-headers.outputs.made-change == 'true'

--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -79,7 +79,7 @@ jobs:
           persist-credentials: true
 
       - name: Add copyright headers
-        uses: UoMResearchIT/actions/reuse@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+        uses: UoMResearchIT/actions/reuse@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
 
         with:
           base-dir: ${{ inputs.work-dir }}
@@ -89,7 +89,7 @@ jobs:
           copyright-holder: ${{ inputs.copyright-holder }}
 
       - name: Delete existing fix-headers branches
-        uses: phpdocker-io/github-actions-delete-abandoned-branches@v2
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@e04764c2f0f714dedb80c42d5174e756568a0452 # v2.02
         id: delete
         with:
           github_token: ${{ github.token }}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Commit and push changes
         id: push
-        uses: UoMResearchIT/actions/git-push-changes-to-branch@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+        uses: UoMResearchIT/actions/git-push-changes-to-branch@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
         with:
           working-directory: ${{ inputs.work-dir }}
           branch-prefix: add-license-headers-to

--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -18,6 +18,7 @@ run-name: "Assign issue #${{ github.event.issue.id }} to default assignee"
 on:
   issues:
     types: [opened]
+permissions: {}
 jobs:
   auto-assign:
     if: vars.DEFAULT_ISSUE_ASSIGNEE != ''

--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -21,6 +21,7 @@ on:
 permissions: {}
 jobs:
   auto-assign:
+    name: Assign Issue to default assignee
     if: vars.DEFAULT_ISSUE_ASSIGNEE != ''
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -53,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
     name: Compare Ruleset Against Standard
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
         timeout-minutes: 1
 
       - name: Create Github App Token

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Fetch Standard Ruleset from ${{ inputs.standard-owner }}/${{ inputs.standard-repo }}
         id: expected
-        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
         with:
           repository: ${{ inputs.standard-owner }}/${{ inputs.standard-repo }}
           token: ${{ steps.mint-token.outputs.token }}
@@ -90,11 +90,11 @@ jobs:
 
       - name: Fetch This Repository's Ruleset
         id: current
-        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
         timeout-minutes: 1
 
       - name: Check Inclusion of Standard Ruleset in Current Ruleset
-        uses: UoMResearchIT/actions/check-ruleset-containment@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+        uses: UoMResearchIT/actions/check-ruleset-containment@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
         with:
           current: ${{ steps.current.outputs.filename }}
           expected: ${{ steps.expected.outputs.filename }}

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -65,14 +65,14 @@ jobs:
           exit 1
 
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
         timeout-minutes: 1
 
       - name: Create Github App Token
         id: mint-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ inputs.bot-id }}
           private-key: ${{ secrets.bot-key }}

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -57,6 +57,13 @@ jobs:
       contents: read
 
     steps:
+      - name: Fail if no credentials
+        if: inputs.bot-id == ''
+        shell: bash
+        run: |
+          echo "No required valid ORG_ACTIONS_BOT_APP_ID supplied; aborting..."
+          exit 1
+
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Fetch Standard Ruleset from ${{ inputs.standard-owner }}/${{ inputs.standard-repo }}
         id: expected
-        uses: UoMResearchIT/actions/get-repo-ruleset@v1.2.4
+        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
         with:
           repository: ${{ inputs.standard-owner }}/${{ inputs.standard-repo }}
           token: ${{ steps.mint-token.outputs.token }}
@@ -90,11 +90,11 @@ jobs:
 
       - name: Fetch This Repository's Ruleset
         id: current
-        uses: UoMResearchIT/actions/get-repo-ruleset@v1.2.4
+        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
         timeout-minutes: 1
 
       - name: Check Inclusion of Standard Ruleset in Current Ruleset
-        uses: UoMResearchIT/actions/check-ruleset-containment@v1.2.4
+        uses: UoMResearchIT/actions/check-ruleset-containment@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
         with:
           current: ${{ steps.current.outputs.filename }}
           expected: ${{ steps.expected.outputs.filename }}

--- a/.github/workflows/enforce-license.yml
+++ b/.github/workflows/enforce-license.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Enforce

--- a/.github/workflows/enforce-license.yml
+++ b/.github/workflows/enforce-license.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Enforce
-        uses: UoMResearchIT/actions/check-copyrights@v1.2.4
+        uses: UoMResearchIT/actions/check-copyrights@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
         with:
           profile: ASL

--- a/.github/workflows/enforce-license.yml
+++ b/.github/workflows/enforce-license.yml
@@ -19,6 +19,7 @@ on: push
 permissions: {}
 jobs:
   check:
+    name: Check
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:

--- a/.github/workflows/enforce-license.yml
+++ b/.github/workflows/enforce-license.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Enforce
         uses: UoMResearchIT/actions/check-copyrights@v1.2.4
         with:

--- a/.github/workflows/enforce-license.yml
+++ b/.github/workflows/enforce-license.yml
@@ -16,6 +16,7 @@ name: Enforce License Rules
 # Enforces our own license rules.
 run-name: License Check
 on: push
+permissions: {}
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-license.yml
+++ b/.github/workflows/enforce-license.yml
@@ -30,6 +30,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Enforce
-        uses: UoMResearchIT/actions/check-copyrights@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+        uses: UoMResearchIT/actions/check-copyrights@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
         with:
           profile: ASL

--- a/.github/workflows/run-zizmor.yml
+++ b/.github/workflows/run-zizmor.yml
@@ -1,6 +1,24 @@
-# SPDX-FileCopyrightText: 2026 University of Manchester
+# MIT License
 #
-# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 The University of Manchester
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 name: GitHub Actions Security Analysis with zizmor 🌈
 

--- a/.github/workflows/run-zizmor.yml
+++ b/.github/workflows/run-zizmor.yml
@@ -24,6 +24,7 @@ permissions: {}
 
 jobs:
   zizmor:
+    name: Scan with Zizmor
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/run-zizmor.yml
+++ b/.github/workflows/run-zizmor.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 University of Manchester
+#
+# SPDX-License-Identifier: MIT
+
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/run-zizmor.yml
+++ b/.github/workflows/run-zizmor.yml
@@ -1,24 +1,16 @@
-# MIT License
-#
 # Copyright (c) 2026 The University of Manchester
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: GitHub Actions Security Analysis with zizmor 🌈
 

--- a/.github/workflows/scan-for-secrets.yml
+++ b/.github/workflows/scan-for-secrets.yml
@@ -47,12 +47,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Checkout default configuration file
         uses: actions/checkout@v6
         with:
           path: .uomrit-actions
           repository: UoMResearchIT/actions
           ref: main
+          persist-credentials: false
       - name: Scan
         uses: secret-scanner/action@0.2.1
         with:

--- a/.github/workflows/scan-for-secrets.yml
+++ b/.github/workflows/scan-for-secrets.yml
@@ -46,18 +46,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Checkout default configuration file
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: .uomrit-actions
           repository: UoMResearchIT/actions
           ref: main
           persist-credentials: false
       - name: Scan
-        uses: secret-scanner/action@0.2.1
+        uses: secret-scanner/action@bf855b904a8bca17a334986797650dacec7ed529 # 0.2.1
         with:
           # Version locked because of bugs
           detect_secrets_version: "1.3.0"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ These are intended for use in many types of project, wherever relevant.
 
 ## Reusable Workflows
 
+> [!WARNING]
+> Do ***not*** call these from `pull_request_target`- or `issue_comment`-triggered workflows.
+
 * [`add_prs_to_project` (reusable workflow)](.github/workflows/add_prs_to_project.yml) is a reusable workflow that you can use in your repository to add any PRs assigned to a user to a Project and set the Status in the project to a value of your choosing.
 
 * [`apply-reuse` (reusable workflow)](.github/workflows/apply-reuse.yml) is a reusable workflow that encodes how to use our branch of [reuse](https://reuse.software/) for managing copyright headers. Intended to be called from PR-triggered workflows.

--- a/check-copyrights/action.yml
+++ b/check-copyrights/action.yml
@@ -65,6 +65,11 @@ branding:
 runs:
   using: composite
   steps:
+    - name: Check version sanity
+      shell: bash
+      run: $GITHUB_ACTION_PATH/checkver.bash
+      env:
+        IN_VERSION: ${{ inputs.version }}
     - name: Cache RAT
       id: cache
       uses: actions/cache@v5

--- a/check-copyrights/action.yml
+++ b/check-copyrights/action.yml
@@ -75,7 +75,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ github.action_path }}/apache-rat-${{ inputs.version }}
-        key: apache-rat-${{ inputs.version }}
+        key: apache-rat-${{ inputs.version }}/${{ github.ref }}
     - name: Download RAT
       if: steps.cache.outputs.cache-hit != 'true'
       run: $GITHUB_ACTION_PATH/download.bash

--- a/check-copyrights/action.yml
+++ b/check-copyrights/action.yml
@@ -72,7 +72,7 @@ runs:
         IN_VERSION: ${{ inputs.version }}
     - name: Cache RAT
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ github.action_path }}/apache-rat-${{ inputs.version }}
         key: apache-rat-${{ inputs.version }}/${{ github.ref }}

--- a/check-copyrights/checkver.bash
+++ b/check-copyrights/checkver.bash
@@ -1,4 +1,6 @@
-# Copyright (c) 2025 The University of Manchester
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directories:
-      - "/"
-      - "/*"
-    schedule:
-      interval: "weekly"
-    assignees:
-      - dkfellows
-    cooldown:
-      default-days: 3
+case "$IN_VERSION" in
+    "[0-9].[0-9][0-9]")
+        exit 0
+        ;;
+    *)
+        echo "Unsupported version: $IN_VERSION"
+        exit 1
+        ;;
+esac

--- a/check-copyrights/checkver.bash
+++ b/check-copyrights/checkver.bash
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 case "$IN_VERSION" in
-    "[0-9].[0-9][0-9]")
+    [0-9].[0-9][0-9])
         exit 0
         ;;
     *)

--- a/configure-nuget-for-github/action.yml
+++ b/configure-nuget-for-github/action.yml
@@ -48,6 +48,6 @@ runs:
         dotnet nuget add source --username "$NGUSER" --password "$NGPASS" --store-password-in-clear-text --name "$NGHNDL" "$NGURL"
       env:
         NGUSER: ${{ github.actor }}
-        NGPASS: ${{ secrets.GITHUB_TOKEN }}
+        NGPASS: ${{ github.token }}
         NGURL: ${{ steps.naming.outputs.url }}
         NGHNDL: ${{ inputs.short-handle }}

--- a/docker-publish-to-ghcr/action.yml
+++ b/docker-publish-to-ghcr/action.yml
@@ -71,8 +71,10 @@ runs:
         password: ${{ inputs.token || github.token }}
     - name: Record that we've logged in
       if: steps.login.outcome == 'success'
-      shell: bash
-      run: echo "uomRIT_docker_login=$ACTOR" >> $GITHUB_ENV
+      uses: actions/github-script@v9
+      with:
+        script: |
+          core.exportVariable('uomRIT_docker_login', process.env.ACTOR)
       env:
         ACTOR: ${{ inputs.actor }}
 

--- a/docker-publish-to-ghcr/action.yml
+++ b/docker-publish-to-ghcr/action.yml
@@ -64,14 +64,14 @@ runs:
     - name: Log in to the Container registry
       id: login
       if: env.uomRIT_docker_login != inputs.actor
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ghcr.io
         username: ${{ inputs.actor }}
         password: ${{ inputs.token || github.token }}
     - name: Record that we've logged in
       if: steps.login.outcome == 'success'
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.exportVariable('uomRIT_docker_login', process.env.ACTOR)

--- a/download/action.yml
+++ b/download/action.yml
@@ -56,7 +56,7 @@ runs:
         LOCALNAME: ${{ inputs.local-name }}
     - name: Check cache
       id: cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         key: download-${{ inputs.url }}
         path: ${{ steps.filename.outputs.file }}

--- a/doxygen-to-pages/README.md
+++ b/doxygen-to-pages/README.md
@@ -38,14 +38,22 @@ If that can't be determined, the environment variable will be set to `https://ex
 
   Defaults to `.`.
 
+* `publish-environment`
+
+  The environment that will be published to. Defaults to `github-pages`, the usual correct value. **Optional.**
+
+  If this environment is not defined in the repository, a debugging artifact containing the Doxygen output will be attached to the workflow run summary page.
+
 ## Outputs
 * `artifact_id`
 
-  The ID of the artifact that was uploaded. The artifact is _not_ deployed by this action.
+  The ID of the artifact that was uploaded, if it is production-ready. The artifact is _not_ deployed by this action.
+
+* `deploy-ready`
+
+  Whether a deployment is possible from what was uploaded. Either `true` or `false`, as strings.
 
 ## Permissions
-Requires at least `pages: read` if a meaningful site URL is to be provided.
+Requires at least `actions: read` and `contents: read`.
 (By contrast, [actions/deploy-pages](https://github.com/actions/deploy-pages)
-_requires both_ `pages: write` _and_ `it-token: write`.)
-
-If not deploying (i.e., because you are going to download the artifact to examine it locally), no special permissions are required.
+_requires both_ `pages: write` _and_ `id-token: write`.)

--- a/doxygen-to-pages/action.yml
+++ b/doxygen-to-pages/action.yml
@@ -17,6 +17,9 @@ author: Donal Fellows
 description: >
   Runs Doxygen and uploads the result as an artifact ready to be deployed to
   Github Pages (see actions/deploy-pages).
+  If no publication environment is set up, just uploads a debug artifact instead
+  so that the contents of the documentation can be examined prior to initial
+  publication.
 branding:
   icon: file-text
   color: blue
@@ -33,7 +36,10 @@ inputs:
 outputs:
   artifact_id:
     description: The ID of the artifact that was uploaded.
-    value: ${{ steps.upload.outputs.artifact_id }}
+    value: ${{ steps.upload.outputs.artifact_id || '' }}
+  deploy-ready:
+    description: Whether a deployment is possible from what was uploaded.
+    value: ${{ steps.upload.outcome == 'success' }}
 runs:
   using: composite
   steps:
@@ -62,5 +68,7 @@ runs:
       if: steps.env-chk.outputs.env-present != 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
+        name: Doxygen HTML Build
         path: ${{ inputs.working-directory }}/html
         if-no-files-found: error
+        retention-days: 3

--- a/doxygen-to-pages/action.yml
+++ b/doxygen-to-pages/action.yml
@@ -35,16 +35,16 @@ runs:
   steps:
     - name: Setup Pages
       id: setup
-      uses: actions/configure-pages@v6
+      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       continue-on-error: true
     - name: Run Doxygen
-      uses: mattnotmitt/doxygen-action@v1.12.0
+      uses: mattnotmitt/doxygen-action@b84fe17600245bb5db3d6c247cc274ea98c15a3b # v1.12.0
       with:
         working-directory: ${{ inputs.working-directory }}
       env:
         SITE_URL: ${{ steps.setup.outputs.base_url || 'https://example.org/' }}
     - name: Upload Artifact
       id: upload
-      uses: actions/upload-pages-artifact@v5
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: ${{ inputs.working-directory }}/html

--- a/doxygen-to-pages/action.yml
+++ b/doxygen-to-pages/action.yml
@@ -26,6 +26,10 @@ inputs:
       The working directory to run Doxygen in.
       Where the `Doxyfile` is located.
     default: .
+  publish-environment:
+    description: >
+      The environment that will be published to.
+    default: github-pages
 outputs:
   artifact_id:
     description: The ID of the artifact that was uploaded.
@@ -33,10 +37,15 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Check for Environment
+      id: env-chk
+      uses: UoMResearchIT/actions/list-environments@55c02a2f91888d43751f94dfaaf53ca2e9d93d14 # main
+      with:
+        has-env: ${{ inputs.publish-environment }}
     - name: Setup Pages
+      if: steps.env-chk.outputs.env-present == 'true'
       id: setup
       uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      continue-on-error: true
     - name: Run Doxygen
       uses: mattnotmitt/doxygen-action@b84fe17600245bb5db3d6c247cc274ea98c15a3b # v1.12.0
       with:
@@ -44,7 +53,14 @@ runs:
       env:
         SITE_URL: ${{ steps.setup.outputs.base_url || 'https://example.org/' }}
     - name: Upload Artifact
+      if: steps.env-chk.outputs.env-present == 'true'
       id: upload
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: ${{ inputs.working-directory }}/html
+    - name: Upload Debug Artifact
+      if: steps.env-chk.outputs.env-present != 'true'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        path: ${{ inputs.working-directory }}/html
+        if-no-files-found: error

--- a/reuse/README.md
+++ b/reuse/README.md
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: REUSE Compliance Check
       uses: UoMResearchIT/reuse@v1.0
@@ -56,7 +56,7 @@ If you would like to run other subcommands, you could use the following snippet 
 
 ```yml
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: REUSE SPDX SBOM
       uses: UoMResearchIT/reuse@v1.0
       with:
@@ -67,7 +67,7 @@ In the same fashion, it is possible to add optional arguments like `--include-su
 
 ```yml
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: REUSE Compliance Check
       uses: UoMResearchIT/reuse@v1.0
       with:

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -140,4 +140,6 @@ runs:
     shell: bash
     run: |
       source reuse-tool-venv/bin/activate
-      reuse ${{ steps.args.outputs.args }}
+      reuse $Arguments
+    env:
+      Arguments: ${{ steps.args.outputs.args }}

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -94,16 +94,18 @@ runs:
     shell: bash
 
   - name: Enable reuse-tool Environment
+    id: venv
     run: |
       source reuse-tool-venv/${SCRIPT_DIR}/activate
-      echo "VIRTUAL_ENV=${VIRTUAL_ENV}" >> $GITHUB_ENV
-      echo "${VIRTUAL_ENV}/${SCRIPT_DIR}" >> $GITHUB_PATH
+      echo "virtual_env=${VIRTUAL_ENV}" >> $GITHUB_OUTPUT
+      echo "path=${VIRTUAL_ENV}/${SCRIPT_DIR}" >> $GITHUB_OUTPUT
     shell: bash
     env:
       SCRIPT_DIR: ${{ runner.os == 'Windows' && 'Scripts' || 'bin' }}
 
   - name: Setup reuse-tool Environment
     run: |
+      PATH="$PATH_ELEMENT:$PATH"
       pip install "poetry~=$USE_POETRY_VERSION"
       cd reuse-tool
       poetry install --no-interaction --only main
@@ -113,6 +115,8 @@ runs:
     shell: bash
     env:
       USE_POETRY_VERSION: ${{ inputs.poetry-version }}
+      VIRTUAL_ENV: ${{ steps.venv.outputs.virtual_env }}
+      PATH_ELEMENT: ${{ steps.venv.outputs.path }}
 
   - name: Save Cache
     uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -139,7 +143,8 @@ runs:
   - name: Run reuse
     shell: bash
     run: |
-      source reuse-tool-venv/bin/activate
+      source "$Venv_Path/activate"
       reuse $Arguments
     env:
       Arguments: ${{ steps.args.outputs.args }}
+      Venv_Path: ${{ steps.venv.outputs.path }}

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -69,12 +69,13 @@ runs:
       path: reuse-tool
       repository: UoMResearchIT/reuse-tool
       ref: ${{ inputs.branch }}
+      persist-credentials: false
 
   - name: Setup Python
     uses: actions/setup-python@v6.2.0
     id: setup-python
     with:
-      python-version: ${{ inputs.python-version}}
+      python-version: ${{ inputs.python-version }}
 
   - name: Clear Problem Matcher
     run: echo '::remove-matcher owner=python::'

--- a/reuse/action.yml
+++ b/reuse/action.yml
@@ -64,7 +64,7 @@ runs:
   using: composite
   steps:
   - name: Checkout
-    uses: actions/checkout@v6
+    uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     with:
       path: reuse-tool
       repository: UoMResearchIT/reuse-tool
@@ -72,7 +72,7 @@ runs:
       persist-credentials: false
 
   - name: Setup Python
-    uses: actions/setup-python@v6.2.0
+    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
     id: setup-python
     with:
       python-version: ${{ inputs.python-version }}
@@ -82,7 +82,7 @@ runs:
     shell: bash
 
   - name: Restore Cache
-    uses: actions/cache/restore@v5.0.5
+    uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
     id: cache-venv
     with:
       path: reuse-tool-venv
@@ -115,7 +115,7 @@ runs:
       USE_POETRY_VERSION: ${{ inputs.poetry-version }}
 
   - name: Save Cache
-    uses: actions/cache/save@v5.0.5
+    uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
     with:
       path: reuse-tool-venv
       key: ${{ steps.cache-venv.outputs.cache-primary-key }}

--- a/run-c-style-check/action.yml
+++ b/run-c-style-check/action.yml
@@ -42,7 +42,7 @@ runs:
   using: composite
   steps:
     - name: install vera
-      uses: UoMResearchIT/actions/apt-get-install@v1.2.4
+      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
       with:
         packages: vera++
     - name: analyse code

--- a/run-c-style-check/action.yml
+++ b/run-c-style-check/action.yml
@@ -42,7 +42,7 @@ runs:
   using: composite
   steps:
     - name: install vera
-      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
       with:
         packages: vera++
     - name: analyse code

--- a/run-clang-tidy/action.yml
+++ b/run-clang-tidy/action.yml
@@ -46,7 +46,7 @@ runs:
   using: composite
   steps:
     - name: Install clang-tidy
-      uses: UoMResearchIT/actions/apt-get-install@v1.2.4
+      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
       with:
         packages: clang-tidy
     - name: Run clang-tidy

--- a/run-clang-tidy/action.yml
+++ b/run-clang-tidy/action.yml
@@ -46,7 +46,7 @@ runs:
   using: composite
   steps:
     - name: Install clang-tidy
-      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
       with:
         packages: clang-tidy
     - name: Run clang-tidy

--- a/run-clang-tidy/action.yml
+++ b/run-clang-tidy/action.yml
@@ -52,10 +52,11 @@ runs:
     - name: Run clang-tidy
       run: |
         [ -f "$USER_CFG" -a -r "$USER_CFG" ] && CFG=$USER_CFG
-        exec clang-tidy ${{ inputs.file-glob }} "--config-file=$CFG" $OPTIONS
+        exec clang-tidy $FILE_GLOB "--config-file=$CFG" $OPTIONS
       env:
         USER_CFG: ${{ inputs.config-file }}
         CFG: ${{ github.action_path }}/.clang-tidy
         OPTIONS: ${{ inputs.options }}
+        FILE_GLOB: ${{ inputs.file-glob }}
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/run-pylint/action.yml
+++ b/run-pylint/action.yml
@@ -104,7 +104,7 @@ runs:
         USER_LANG: ${{ inputs.language }}
     - name: Install spell checker
       if: inputs.language != ''
-      uses: UoMResearchIT/actions/apt-get-install@v1.2.4
+      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
       with:
         packages: enchant-2 hunspell libhunspell-dev ${{ steps.lang.outputs.pkg }}
     - name: Build composite dictionary

--- a/run-pylint/action.yml
+++ b/run-pylint/action.yml
@@ -84,7 +84,7 @@ runs:
     - name: Set up python if not already done
       id: python
       if: env.pythonLocation == ''
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
     - name: Ensure critical Python packages are set up right

--- a/run-pylint/action.yml
+++ b/run-pylint/action.yml
@@ -104,7 +104,7 @@ runs:
         USER_LANG: ${{ inputs.language }}
     - name: Install spell checker
       if: inputs.language != ''
-      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 #v1.2.4
+      uses: UoMResearchIT/actions/apt-get-install@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
       with:
         packages: enchant-2 hunspell libhunspell-dev ${{ steps.lang.outputs.pkg }}
     - name: Build composite dictionary


### PR DESCRIPTION
This PR adds scanning for a bunch of problems with GitHub Actions using a tool called [zizmor](https://github.com/zizmorcore/zizmor). It also fixes those problems.

I do not suggest adding this tool to all our repositories. It's mostly relevant for public ones; private repositories are much less vulnerable to malicious pull requests and commenting.

Also includes an enhancement to the `doxygen-to-pages` action in light of what the `list-environments` action can do, and based on experience from projects.

## To Do
- [x] Validate the changes actually work by running the _actions_ from other repositories.
- [x] Validate the changes actually work by running the _reusable workflows_ from other repositories.

## Validation

* UoMResearchIT/Actions-Test#23