### PR TITLE
Update version of node.js

### DIFF
--- a/instantiate-file/action.yml
+++ b/instantiate-file/action.yml
@@ -35,6 +35,6 @@ outputs:
   filename:
     description: The full name of the file that the value was written to.
 runs:
-  using: node20
+  using: node24
   main: main.js
   post: main.js


### PR DESCRIPTION
Withdrawal of Node version 20 is imminent. We need to update before things break.
