### PR TITLE
Added ignore action input and updated the check bash file and readme

### DIFF
--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -43,6 +43,11 @@ on:
         type: string
         default: RSE-Repository-Template
         required: false
+      ignore:
+        description: JSON array of parameter paths to ignore
+        type: string
+        required: false
+        default: '[]'
     secrets:
       bot-key:
         description: The ORG_ACTIONS_BOT_PRIVATE_KEY from the organisation secrets.
@@ -98,4 +103,5 @@ jobs:
         with:
           current: ${{ steps.current.outputs.filename }}
           expected: ${{ steps.expected.outputs.filename }}
+          ignore: ${{ inputs.ignore }}
         timeout-minutes: 1

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -99,7 +99,7 @@ jobs:
         timeout-minutes: 1
 
       - name: Check Inclusion of Standard Ruleset in Current Ruleset
-        uses: UoMResearchIT/actions/check-ruleset-containment@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
+        uses: UoMResearchIT/actions/check-ruleset-containment@142-frq-check-ruleset-should-allow-exceptions # Temporary feature branch to allow the ignore features to be used
         with:
           current: ${{ steps.current.outputs.filename }}
           expected: ${{ steps.expected.outputs.filename }}

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -99,7 +99,7 @@ jobs:
         timeout-minutes: 1
 
       - name: Check Inclusion of Standard Ruleset in Current Ruleset
-        uses: UoMResearchIT/actions/check-ruleset-containment@8839be4e18a5a880aa052da40d9730445bb42e99 # Temporary feature branch to allow the ignore features to be used
+        uses: UoMResearchIT/actions/check-ruleset-containment@77805abee9d484f0f2b606de7796afa2024fb1e4 # Temporary feature branch to allow the ignore features to be used
         with:
           current: ${{ steps.current.outputs.filename }}
           expected: ${{ steps.expected.outputs.filename }}

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -99,7 +99,7 @@ jobs:
         timeout-minutes: 1
 
       - name: Check Inclusion of Standard Ruleset in Current Ruleset
-        uses: UoMResearchIT/actions/check-ruleset-containment@142-frq-check-ruleset-should-allow-exceptions # Temporary feature branch to allow the ignore features to be used
+        uses: UoMResearchIT/actions/check-ruleset-containment@7a30635d87460270dde919e71e31c5dd1f789f20 # Temporary feature branch to allow the ignore features to be used
         with:
           current: ${{ steps.current.outputs.filename }}
           expected: ${{ steps.expected.outputs.filename }}

--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -99,7 +99,7 @@ jobs:
         timeout-minutes: 1
 
       - name: Check Inclusion of Standard Ruleset in Current Ruleset
-        uses: UoMResearchIT/actions/check-ruleset-containment@7a30635d87460270dde919e71e31c5dd1f789f20 # Temporary feature branch to allow the ignore features to be used
+        uses: UoMResearchIT/actions/check-ruleset-containment@8839be4e18a5a880aa052da40d9730445bb42e99 # Temporary feature branch to allow the ignore features to be used
         with:
           current: ${{ steps.current.outputs.filename }}
           expected: ${{ steps.expected.outputs.filename }}

--- a/check-ruleset-containment/README.md
+++ b/check-ruleset-containment/README.md
@@ -11,6 +11,7 @@ Example:
         with:
           current: ${{ steps.get-rules.outputs.filename }}
           expected: project_setup/my_ruleset_file.json
+		  ignore: '["enforcement", "required_status_checks.strict"]'
 ```
 
 > [!NOTE]
@@ -24,6 +25,13 @@ Example:
 * `expected`
 
   The name of the file containing the "expected" ruleset to check against. **Required.**
+  
+* `ignore`
+
+  A JSON array of parameter paths to ignore when comparing rulesets. **Optional.**
+  - Supports nested paths using dot notation (e.g. a.b.c)
+  - Ignored parameters are removed from both rulesets before comparison
+  - Differences in ignored parameters (including missing keys) are not reported
 
 ## Outputs
 None.

--- a/check-ruleset-containment/README.md
+++ b/check-ruleset-containment/README.md
@@ -28,7 +28,7 @@ Example:
   
 * `ignore`
 
-  A JSON array of parameter paths to ignore when comparing rulesets. **Optional.**
+  A JSON array of parameter paths to ignore when comparing rulesets. **Optional.**
   - Supports nested paths using dot notation (e.g. a.b.c)
   - Ignored parameters are removed from both rulesets before comparison
   - Differences in ignored parameters (including missing keys) are not reported

--- a/check-ruleset-containment/README.md
+++ b/check-ruleset-containment/README.md
@@ -11,7 +11,7 @@ Example:
         with:
           current: ${{ steps.get-rules.outputs.filename }}
           expected: project_setup/my_ruleset_file.json
-		  ignore: '["enforcement", "required_status_checks.strict"]'
+          ignore: '["enforcement", "required_status_checks.strict"]'
 ```
 
 > [!NOTE]

--- a/check-ruleset-containment/action.yml
+++ b/check-ruleset-containment/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: true
   ignore:
     description: >-
-      JSON array of parameter keys to ignore when comparing rulesets.
+      JSON array of parameter paths to ignore when comparing rulesets (supports dot notation, e.g. "required_status_checks.strict").
       e.g. '["enforcement","bypass_actors"]'
     required: false
     default: '[]'

--- a/check-ruleset-containment/action.yml
+++ b/check-ruleset-containment/action.yml
@@ -29,6 +29,12 @@ inputs:
     description: >
       The name of the file containing the "expected" ruleset to check against.
     required: true
+  ignore:
+    description: >-
+      JSON array of parameter keys to ignore when comparing rulesets.
+      e.g. '["enforcement","bypass_actors"]'
+    required: false
+    default: '[]'
 runs:
   using: composite
   steps:
@@ -38,3 +44,4 @@ runs:
       env:
         CURRENT_FILE: ${{ inputs.current }}
         EXPECTED_FILE: ${{ inputs.expected }}
+        IGNORE_KEYS: ${{ inputs.ignore }}

--- a/check-ruleset-containment/check.bash
+++ b/check-ruleset-containment/check.bash
@@ -38,6 +38,7 @@ def drop_paths($paths):
 ACTUAL_RULES=$(jq -c \
   --argjson ignore "$IGNORE_PATHS" \
   "$DROP_PATHS_JQ
+  ;
   map({
     type,
     parameters: (
@@ -50,6 +51,7 @@ ACTUAL_RULES=$(jq -c \
 EXPECTED_RULES=$(jq -c \
   --argjson ignore "$IGNORE_PATHS" \
   "$DROP_PATHS_JQ
+  ;
   map({
     type,
     parameters: (

--- a/check-ruleset-containment/check.bash
+++ b/check-ruleset-containment/check.bash
@@ -38,12 +38,11 @@ def drop_paths($paths):
 ACTUAL_RULES=$(jq -c \
   --argjson ignore "$IGNORE_PATHS" \
   "$DROP_PATHS_JQ
-  ;
   map({
     type,
     parameters: (
       (.parameters // {})
-      | drop_paths($ignore)
+      | drop_paths(\$ignore)
     )
   })
 " "$CURRENT_FILE")
@@ -51,12 +50,11 @@ ACTUAL_RULES=$(jq -c \
 EXPECTED_RULES=$(jq -c \
   --argjson ignore "$IGNORE_PATHS" \
   "$DROP_PATHS_JQ
-  ;
   map({
     type,
     parameters: (
       (.parameters // {})
-      | drop_paths($ignore)
+      | drop_paths(\$ignore)
     )
   })
 " "$EXPECTED_FILE")

--- a/check-ruleset-containment/check.bash
+++ b/check-ruleset-containment/check.bash
@@ -23,8 +23,11 @@ yellow=$(printf '\033[0;33m')
 reset=$(printf '\033[0m')
 
 # Build ignore paths (supports nested like a.b.c)
-IGNORE_PATHS=$(echo "$IGNORE_KEYS" | jq -c 'map(split("."))')
-
+IGNORE_KEYS_JSON=${IGNORE_KEYS:-'[]'}
+if ! IGNORE_PATHS=$(jq -ce 'if type == "array" then map(tostring | split(".")) else error("ignore must be a JSON array") end' <<<"$IGNORE_KEYS_JSON"); then
+  echo "${red}Error:${reset} 'ignore' input must be a JSON array of strings, e.g. [\"enforcement\",\"required_status_checks.strict\"]."
+  exit 1
+fi
 # jq helper to drop nested paths
 DROP_PATHS_JQ='
 def drop_paths($paths):

--- a/check-ruleset-containment/check.bash
+++ b/check-ruleset-containment/check.bash
@@ -22,9 +22,39 @@ green=$(printf '\033[0;32m')
 yellow=$(printf '\033[0;33m')
 reset=$(printf '\033[0m')
 
+# Build ignore paths (supports nested like a.b.c)
+IGNORE_PATHS=$(echo "$IGNORE_KEYS" | jq -c 'map(split("."))')
+
+# jq helper to drop nested paths
+DROP_PATHS_JQ='
+def drop_paths($paths):
+  reduce $paths[] as $p (.; delpaths([$p]));
+'
+
 # Load actual and expected rulesets using jq
-ACTUAL_RULES=$(jq -c 'map({type, parameters: (if has("parameters") then .parameters else {} end)})' "$CURRENT_FILE")
-EXPECTED_RULES=$(jq -c 'map({type, parameters: (if has("parameters") then .parameters else {} end)})' "$EXPECTED_FILE")
+ACTUAL_RULES=$(jq -c \
+  --argjson ignore "$IGNORE_PATHS" \
+  "$DROP_PATHS_JQ
+  map({
+    type,
+    parameters: (
+      (.parameters // {})
+      | drop_paths($ignore)
+    )
+  })
+" "$CURRENT_FILE")
+
+EXPECTED_RULES=$(jq -c \
+  --argjson ignore "$IGNORE_PATHS" \
+  "$DROP_PATHS_JQ
+  map({
+    type,
+    parameters: (
+      (.parameters // {})
+      | drop_paths($ignore)
+    )
+  })
+" "$EXPECTED_FILE")
 
 echo ::group::Data to compare
 echo "${yellow}Actual Rules:${reset} $ACTUAL_RULES"


### PR DESCRIPTION
This pull request enhances the `check-ruleset-containment` GitHub Action by adding support for ignoring specific parameter paths when comparing rulesets. This makes the action more flexible, allowing users to exclude certain fields (including nested ones) from the comparison process. The changes include updates to the action's documentation, input definitions, and comparison logic.

**Feature: Ignore Parameter Paths in Ruleset Comparison**
- **Action logic and script updates:**
  * The comparison logic in `check.bash` now supports an `ignore` input, which is a JSON array of parameter paths (including nested paths using dot notation) to be ignored during ruleset comparison. These paths are removed from both rulesets before comparison, ensuring differences in ignored parameters are not reported.
  * The `IGNORE_KEYS` environment variable is passed to the script, and the default value for `ignore` is set to an empty array. [[1]](diffhunk://#diff-fb93aa1a387bbb163beaa9b0592dfada43beef77e5d4a5257e4af05fadff9f77R47) [[2]](diffhunk://#diff-fb93aa1a387bbb163beaa9b0592dfada43beef77e5d4a5257e4af05fadff9f77R32-R37)

- **Documentation updates:**
  * The `README.md` is updated to document the new `ignore` input, including usage examples and a description of its behaviour. [[1]](diffhunk://#diff-d518e92517eca285a604058b7c19fb51f1e7c2cc60976ce97ca83272bc2ff5a5R14) [[2]](diffhunk://#diff-d518e92517eca285a604058b7c19fb51f1e7c2cc60976ce97ca83272bc2ff5a5R29-R35)
  * The `action.yml` input definitions are updated to include the new `ignore` input, with a description and example usage.

These changes make the action more robust and adaptable to different ruleset comparison needs.