### PR TITLE
Limit permissions in check-ruleset

### DIFF
--- a/.github/workflows/check-ruleset.yaml
+++ b/.github/workflows/check-ruleset.yaml
@@ -83,11 +83,12 @@ jobs:
           private-key: ${{ secrets.bot-key }}
           owner: ${{ inputs.standard-owner }}
           repositories: ${{ inputs.standard-repo }}
+          permission-contents: read
         timeout-minutes: 1
 
       - name: Fetch Standard Ruleset from ${{ inputs.standard-owner }}/${{ inputs.standard-repo }}
         id: expected
-        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
+        uses: UoMResearchIT/actions/get-repo-ruleset@d1daa552b595b77a4628d28de138db571e91ab87 # v1.2.5
         with:
           repository: ${{ inputs.standard-owner }}/${{ inputs.standard-repo }}
           token: ${{ steps.mint-token.outputs.token }}
@@ -95,7 +96,7 @@ jobs:
 
       - name: Fetch This Repository's Ruleset
         id: current
-        uses: UoMResearchIT/actions/get-repo-ruleset@4e469793f6f793229bac2ebed8a7479b31883072 # v1.2.4
+        uses: UoMResearchIT/actions/get-repo-ruleset@d1daa552b595b77a4628d28de138db571e91ab87 # v1.2.5
         timeout-minutes: 1
 
       - name: Check Inclusion of Standard Ruleset in Current Ruleset

--- a/get-repo-ruleset/README.md
+++ b/get-repo-ruleset/README.md
@@ -45,4 +45,4 @@ Example:
 
 ## Permissions
 No special permissions required when accessing the current repository's ruleset.
-If accessing a different repository, an appropriate PAT will be required.
+If accessing a different repository, an appropriate PAT or app token will be required.


### PR DESCRIPTION
This PR is about trying to limit the permissions granted more specifically in the `check-ruleset` workflow.

It also pins some versions later and corrects a README.