### PR TITLE
Update the ref in the secret scanner to something on the right branch

### DIFF
--- a/.github/workflows/scan-for-secrets.yml
+++ b/.github/workflows/scan-for-secrets.yml
@@ -58,7 +58,7 @@ jobs:
           path: .uomrit-actions
           sparse-checkout: .github/secret-scanner
           repository: UoMResearchIT/actions
-          ref: af043d6d68df41a88dfe8d8f71088f9440dfb6d8  # secret-scanner
+          ref: 88866a7934412523ee31db7692ef86ebbdfce1ed  # main
           persist-credentials: false
         timeout-minutes: 1
       - name: Select configuration
@@ -69,7 +69,7 @@ jobs:
           CFG: ${{ inputs.config-file }}
           DFLT: .uomrit-actions/.github/secret-scanner/baseline.json
       - name: Scan
-        uses: UoMResearchIT/actions/secret-scanner@af043d6d68df41a88dfe8d8f71088f9440dfb6d8  # secret-scanner
+        uses: UoMResearchIT/actions/secret-scanner@88866a7934412523ee31db7692ef86ebbdfce1ed  # main
         with:
           baseline-file: ${{ steps.cfg.outputs.file }}
           exclude-path: ${{ inputs.exclude-path }}


### PR DESCRIPTION
Needed this PR-let because I wanted the git ref to be something on `main`, not on the branch.