### PR TITLE
Better Doxygen action

### DIFF
--- a/doxygen-to-pages/README.md
+++ b/doxygen-to-pages/README.md
@@ -44,10 +44,21 @@ If that can't be determined, the environment variable will be set to `https://ex
 
   If this environment is not defined in the repository, a debugging artifact containing the Doxygen output will be attached to the workflow run summary page.
 
+* `doxygen-version`
+
+  The version of Doxygen to use. Defaults to `1.9.8`. **Optional.**
+
+  Any version that has a binary release for Linux published on GitHub is supported.
+  See https://github.com/doxygen/doxygen/releases for the supported versions.
+
 ## Outputs
 * `artifact_id`
 
   The ID of the artifact that was uploaded, if it is production-ready. The artifact is _not_ deployed by this action.
+
+* `debug-artifact_id`
+
+  The ID of the debug artifact that was uploaded, if it is _not_ a production-ready upload. Note that debug artifacts are easier to extract and view than main artifacts.
 
 * `deploy-ready`
 

--- a/doxygen-to-pages/action.yml
+++ b/doxygen-to-pages/action.yml
@@ -33,10 +33,19 @@ inputs:
     description: >
       The environment that will be published to.
     default: github-pages
+  doxygen-version:
+    description: >
+      The version of Doxygen to use.
+      Any version that has a binary release for Linux published on GitHub is supported.
+      See https://github.com/doxygen/doxygen/releases
+    default: "1.9.8"
 outputs:
   artifact_id:
     description: The ID of the artifact that was uploaded.
     value: ${{ steps.upload.outputs.artifact_id || '' }}
+  debug-artifact_id:
+    description: The ID of the debug artifact that was uploaded.
+    value: ${{ steps.debug-upload.outputs.artifact_id || '' }}
   deploy-ready:
     description: Whether a deployment is possible from what was uploaded.
     value: ${{ steps.upload.outcome == 'success' }}
@@ -45,18 +54,28 @@ runs:
   steps:
     - name: Check for Environment
       id: env-chk
-      uses: UoMResearchIT/actions/list-environments@d1daa552b595b77a4628d28de138db571e91ab87 # v1.2.5
+      uses: UoMResearchIT/actions/list-environments@b747e3097a2cb9d927b63e2bb83fbf6e75716a53 # v1.2.6
       with:
         has-env: ${{ inputs.publish-environment }}
     - name: Setup Pages
       if: steps.env-chk.outputs.env-present == 'true'
       id: setup
       uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-    - name: Run Doxygen
-      uses: mattnotmitt/doxygen-action@b84fe17600245bb5db3d6c247cc274ea98c15a3b # v1.12.0
+    - name: Install Dependencies
+      uses: UoMResearchIT/actions/apt-get-install@b747e3097a2cb9d927b63e2bb83fbf6e75716a53 # v1.2.6
       with:
-        working-directory: ${{ inputs.working-directory }}
+        packages: wget graphviz
+    - name: Install Doxygen v${{ inputs.doxygen-version }}
+      shell: bash
+      run: exec $GITHUB_ACTION_PATH/download.bash
       env:
+        DOXY_VER: ${{ inputs.doxygen-version }}
+    - name: Run Doxygen
+      shell: bash
+      run: "${DOXY_PATH}/doxygen"
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        DOXY_PATH: ${{ github.workspace }}/doxygen-${{ inputs.doxygen-version }}/bin
         SITE_URL: ${{ steps.setup.outputs.base_url || 'https://example.org/' }}
     - name: Upload Artifact
       if: steps.env-chk.outputs.env-present == 'true'
@@ -66,6 +85,7 @@ runs:
         path: ${{ inputs.working-directory }}/html
     - name: Upload Debug Artifact
       if: steps.env-chk.outputs.env-present != 'true'
+      id: debug-upload
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Doxygen HTML Build

--- a/doxygen-to-pages/action.yml
+++ b/doxygen-to-pages/action.yml
@@ -72,7 +72,9 @@ runs:
         DOXY_VER: ${{ inputs.doxygen-version }}
     - name: Run Doxygen
       shell: bash
-      run: "${DOXY_PATH}/doxygen"
+      run: |
+        echo "::add-matcher::${GITHUB_ACTION_PATH}/doxygen-problem-matcher.json"
+        "${DOXY_PATH}/doxygen"
       working-directory: ${{ inputs.working-directory }}
       env:
         DOXY_PATH: ${{ github.workspace }}/doxygen-${{ inputs.doxygen-version }}/bin

--- a/doxygen-to-pages/download.bash
+++ b/doxygen-to-pages/download.bash
@@ -1,4 +1,6 @@
-# Copyright (c) 2025 The University of Manchester
+#!/usr/bin/env bash
+
+# Copyright (c) 2026 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-*.yml linguist-detectable
-*.yaml linguist-detectable
-*.bash text eol=lf
+
+set -e
+
+rel_name="Release_$(echo "$DOXY_VER" | tr '.' '_')"
+url="https://github.com/doxygen/doxygen/releases/download/${rel_name}/doxygen-${DOXY_VER}.linux.bin.tar.gz"
+echo "Download from: ${url}"
+echo ""
+
+wget -nv -O - "$url" | tar -xzf -

--- a/doxygen-to-pages/doxygen-problem-matcher.json
+++ b/doxygen-to-pages/doxygen-problem-matcher.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "doxygen",
+            "pattern": [
+                {
+                    "regexp": "^.*\/(.+):([0-9]+): ([a-zA-Z]+): (.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows a wider range of Doxygen versions to be used. This was previously limited to that supported by the Ubuntu release (and which was consequently very old, missing quite a few bug fixes), but it turns out we can pull binaries direct from GitHub.

Idea "borrowed" from DenverCoder1/doxygen-github-pages-action#30 but I like my version better.