### PR TITLE
Tweak the PR message generation

### DIFF
--- a/.github/workflows/apply-reuse.yml
+++ b/.github/workflows/apply-reuse.yml
@@ -125,22 +125,18 @@ jobs:
           body: >
             Copyright updates at [.../compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1), please review and merge.
 
-      - name: Hide old PR comments
-        if: needs.add-headers.outputs.made-change == 'false'
-        uses: kanga333/comment-hider@c12bb20b48aeb8fc098e35967de8d4f8018fffdf # v0.4.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: PR comment
-        if: needs.add-headers.outputs.made-change == 'true'
         uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11.0
         with:
           refresh-message-position: true
+          message-id: reuse-changes
+          status: ${{ needs.add-headers.outputs.made-change == 'true' && 'success' || 'failure' }}
+          delete-on-status: failure
           message: |
             ## Changes were made to copyright notices
             There are copyright updates on the (temporary) [${{ needs.add-headers.outputs.branch }} branch](${{ github.server_url }}/${{ github.repository }}/compare/${{ inputs.branch }}...${{ needs.add-headers.outputs.branch }}?expand=1). Please review and merge, or add further commits (this branch will be deleted).
 
-      - name: Fail marker
+      - name: Generate failure marker
         if: needs.add-headers.outputs.made-change == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
This allows other uses of the action in the same PR, which is useful because they might be reporting the results of a build of the code. (Or at least that's how I'm using them over [here](https://github.com/UoMResearchIT/Control-System-GUI-2DS/).) I also do a bit of trickery to make the commenter action do deletions in the correct case, instead of needing a separate action for that.